### PR TITLE
feat: change word address to 32 bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,18 @@
 - [강의](https://www.inflearn.com/course/%ED%98%BC%EC%9E%90-%EA%B3%B5%EB%B6%80%ED%95%98%EB%8A%94-%EC%BB%B4%ED%93%A8%ED%84%B0%EA%B5%AC%EC%A1%B0-%EC%9A%B4%EC%98%81%EC%B2%B4%EC%A0%9C/dashboard)
 
 - [개발 일지](https://www.inflearn.com/blogs/9185)
+
+- 디자인 결정들
+
+    - 32비트의 고정된 길이의 명령어, 1비트 opcode, 1bit register operand, 2bit data operand
+        - 초기에 가변 길이 명령어를 사용하였으나, fetch, decode, execute 각 단계마다 명령어 종류에 
+          따라 switch문을 실행하는 것이 번거로울 것 같아 고정된 길이를 사용하였습니다.
+        - 가변 길이 명령어를 사용하는 CPU들이 마이크로코드를 사용한다는 것을 확인하였기 때문에,
+          실제 CPU의 작동 방식과 점점 멀어지고 자료 조사 시 어려울 것 같았습니다.
+
+    - 32비트 워드, 16비트 주소공간
+        - 기존에 16비트 워드, 16비트 주소공간, 32비트 길이 명령어를 만들었습니다.
+          그런데 fetch 한 번을 위해 메모리에 여러 번 접근하는 것이 아쉬웠습니다.
+        - 16비트 워드의 경우 Immediate addressing mode에서 사용할 수 있는 값이 16비트로 한정되어 있습니다.
+          그래서 기존의 LOAD_IMMEDIATE 명령어를 LOAD_IMMEDIATE_1, LOAD_IMMEDIATE_2로 바꾸어 각각
+          {least, most} significant 16비트를 세팅할 수 있도록 하였습니다.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
     - 32비트 워드, 16비트 주소공간
         - 기존에 16비트 워드, 16비트 주소공간, 32비트 길이 명령어를 만들었습니다.
           그런데 fetch 한 번을 위해 메모리에 여러 번 접근하는 것이 아쉬웠습니다.
-        - 16비트 워드의 경우 Immediate addressing mode에서 사용할 수 있는 값이 16비트로 한정되어 있습니다.
+        - 워드 크기를 32비트로 만들 경우 Immediate addressing mode에서 사용할 수 있는 값이 16비트로
+          한정되어 있다는 것이 새로운 고려 대상입니다.
           그래서 기존의 LOAD_IMMEDIATE 명령어를 LOAD_IMMEDIATE_1, LOAD_IMMEDIATE_2로 바꾸어 각각
           {least, most} significant 16비트를 세팅할 수 있도록 하였습니다.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@
           한정되어 있다는 것이 새로운 고려 대상입니다.
           그래서 기존의 LOAD_IMMEDIATE 명령어를 LOAD_IMMEDIATE_1, LOAD_IMMEDIATE_2로 바꾸어 각각
           {least, most} significant 16비트를 세팅할 수 있도록 하였습니다.
+        - fetch, decode, execute을 분리하여 구현하기 더 편해졌습니다.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@
           그래서 기존의 LOAD_IMMEDIATE 명령어를 LOAD_IMMEDIATE_1, LOAD_IMMEDIATE_2로 바꾸어 각각
           {least, most} significant 16비트를 세팅할 수 있도록 하였습니다.
         - fetch, decode, execute을 분리하여 구현하기 더 편해졌습니다.
+        - 참고 자료
+            - [ARM](https://developer.arm.com/documentation/dui0473/m/writing-arm-assembly-language/load-immediate-values)

--- a/cpu.test.ts
+++ b/cpu.test.ts
@@ -1,54 +1,38 @@
 import { test, expect } from "@jest/globals";
 import { Cpu, Opcode, Register } from "./cpu";
-import { Byte, Word } from "./lib";
+import { Byte, getWordFromBytes, Word } from "./lib";
 
 const { R1, R2 } = Register;
-const { LOAD_DIRECT, LOAD_IMMEDIATE, STORE_DIRECT, NOP, ADD } = Opcode;
-
-test("can fetch instructions of opcode + register + 2 byte data", () => {
-    const memory: Byte[] = Array(65536).fill(0x00);
-    // prettier-ignore
-    const program: Byte[] = [
-        LOAD_DIRECT, R1, 0x00, 0x01,
-        LOAD_IMMEDIATE, R2, 0x02, 0x00,
-        NOP, 0x00, 0x00, 0x00,
-        ADD, R1, R2, 0x00,
-        STORE_DIRECT, R1, 0x00, 0x01,
-    ];
-    program.forEach((byte, i) => memory[i] = byte);
-    const cpu = new Cpu(memory);
-    const instructions: Word[] = [];
-    while (cpu.programCounter < program.length) {
-        cpu.handleInstruction();
-        instructions.push(cpu.instructionRegister);
-    }
-    expect(instructions).toEqual([
-        LOAD_DIRECT,
-        LOAD_IMMEDIATE,
-        NOP,
-        ADD,
-        STORE_DIRECT,
-    ]);
-});
+const { LOAD_DIRECT, LOAD_IMMEDIATE_1, LOAD_IMMEDIATE_2, STORE_DIRECT, NOP, ADD } = Opcode;
 
 test("can load and store", () => {
     const memory: Byte[] = Array(65536).fill(0x00);
-    memory[256] = 0x00;
-    memory[257] = 0x10;
+    memory[256] = 0x01;
+    memory[257] = 0x23;
+    memory[258] = 0x45;
+    memory[259] = 0x67;
     // prettier-ignore
     const program: Byte[] = [
-        LOAD_DIRECT, R1, 0x00, 0x01, // Offset 256
-        LOAD_IMMEDIATE, R2, 0x02, 0x00,
-        STORE_DIRECT, R1, 0x02, 0x01,
-        STORE_DIRECT, R2, 0x00, 0x01,
+        LOAD_DIRECT, R1, 0x00, 0x01, // Address 256
+        LOAD_IMMEDIATE_1, R2, 0x02, 0x03, // sets the lower two bytes
+        LOAD_IMMEDIATE_2, R2, 0x04, 0x05, // sets the higher two bytes
+        STORE_DIRECT, R2, 0x00, 0x01, // Address 256
+        STORE_DIRECT, R1, 0x04, 0x01, // Address 260
     ];
     program.forEach((byte, i) => memory[i] = byte);
+
     const cpu = new Cpu(memory);
     while (cpu.programCounter < program.length) {
         cpu.handleInstruction();
     }
+
     expect(memory[256]).toBe(0x02);
-    expect(memory[257]).toBe(0x00);
-    expect(memory[258]).toBe(0x00);
-    expect(memory[259]).toBe(0x10);
+    expect(memory[257]).toBe(0x03);
+    expect(memory[258]).toBe(0x04);
+    expect(memory[259]).toBe(0x05);
+
+    expect(memory[260]).toBe(0x01);
+    expect(memory[261]).toBe(0x23);
+    expect(memory[262]).toBe(0x45);
+    expect(memory[263]).toBe(0x67);
 });

--- a/cpu.ts
+++ b/cpu.ts
@@ -99,7 +99,8 @@ export class Cpu {
     }
 
     handleInstruction() {
-        this.cu.fetchAndDecode();
+        this.cu.fetch();
+        this.cu.decode();
         this.alu.execute();
     }
 }
@@ -158,14 +159,16 @@ export class CpuControlUnit {
         this.cpu.memory[this.memoryAddressRegister + 3] = byte3;
     }
 
-    fetchAndDecode() {
+    fetch() {
         this.loadWord(this.programCounter + OPCODE_OFFSET);
         this.instructionRegister = this.memoryBufferRegister;
+        this.programCounter += INSTRUCTION_LENGTH;
+    }
 
+    decode() {
         this.cpu.alu.inputOpcode = this.instructionRegister & 0xff;
         this.cpu.alu.inputRegisterName = (this.instructionRegister >> 8) & 0xff;
         this.cpu.alu.inputData = this.instructionRegister >> 16;
-        this.programCounter += INSTRUCTION_LENGTH;
     }
 }
 

--- a/lib.ts
+++ b/lib.ts
@@ -1,15 +1,23 @@
 export type Byte = number;
-export type Word = number; // 2 bytes
+export type Word = number; // 4 bytes
 
 /**
  * Bytes are in little-endian order
  */
-export function getWordFromBytes(byte0: Byte, byte1: Byte): Word {
-    return byte0 + byte1 * 256;
+export function getWordFromBytes(
+    byte0: Byte,
+    byte1: Byte,
+    byte2: Byte,
+    byte3: Byte
+): Word {
+    return byte0 + (byte1 << 8) + (byte2 << 16) + (byte3 << 24);
 }
 
-export function getBytesFromWord(word: Word): [Byte, Byte] {
-    const byte0 = (word % 256) as Byte;
-    const byte1 = (((word - byte0) / 256) % 256) as Byte;
-    return [byte0, byte1];
+
+export function getBytesFromWord(word: Word): [Byte, Byte, Byte, Byte] {
+    const byte0 = (word & 0xff) as Byte;
+    const byte1 = ((word >> 8) & 0xff) as Byte;
+    const byte2 = ((word >> 16) & 0xff) as Byte;
+    const byte3 = ((word >> 24) & 0xff) as Byte;
+    return [byte0, byte1, byte2, byte3];
 }


### PR DESCRIPTION
16비트 대신 32비트 워드를 사용함으로서 다음 장점이 있었습니다.

- 32비트 명령어를 fetch하기 위해서 메모리 접근을 1번만 할 수 있다.
- fetch와 decode가 더 깔끔하게 분리되었다.

반면 다음의 어려움이 있었습니다.

- operand로 사용할 수 있는 명령어의 크기가 16비트밖에 되지 않아,
  Immediate 주소 지정 모드에 대해서 수정이 필요했습니다.

- 워드 크기와 동일한 32비트 주소공간을 사용하고 싶었으나,
  직접 주소 지정 모드의 경우 오퍼랜드 크기가 16비트에 불과해
  16비트 주소 공간을 사용합니다.
