### PR TITLE
set halt opcode to 0

### DIFF
--- a/src/cpu.test.ts
+++ b/src/cpu.test.ts
@@ -121,3 +121,21 @@ describe("mov instruction", () => {
         expect(loadWordAtAddress(memory, 0x0100)).toEqual(0x04030201);
     });
 });
+
+describe("add instruction", () => {
+    test("add should add the contents from one register to another", () => {
+        const program = [
+            LOAD_IMMEDIATE_1, R0, 0x01, 0x02,
+            LOAD_IMMEDIATE_2, R0, 0x03, 0x04,
+            LOAD_IMMEDIATE_1, R1, 0x01, 0x01,
+            LOAD_IMMEDIATE_2, R1, 0x01, 0x01,
+            ADD, R1, R0, 0x00,
+            STORE_DIRECT, R1, 0x00, 0x01,
+            HALT, 0x00, 0x00, 0x00,
+        ];
+        const memory = createLargeZeroMemory();
+        loadProgram(memory, program);
+        runProgram(memory);
+        expect(loadWordAtAddress(memory, 0x0100)).toEqual(0x05040302);
+    });
+});

--- a/src/cpu.ts
+++ b/src/cpu.ts
@@ -30,8 +30,8 @@ function defaultRegisters(): Record<Register, Word> {
 }
 
 export enum Opcode {
+    HALT = 0,
     NOP,
-    HALT,
     LOAD_IMMEDIATE_1,
     LOAD_IMMEDIATE_2,
     LOAD_DIRECT,
@@ -44,7 +44,6 @@ export enum Opcode {
     MUL,
     JMP,
     JNZ,
-    END,
 }
 
 type FlagsRegister = {
@@ -175,10 +174,10 @@ export class CpuArithmeticLogicUnit {
 
     execute() {
         switch (this.inputOpcode) {
-            case Opcode.NOP: {
+            case Opcode.HALT: {
                 return;
             }
-            case Opcode.HALT: {
+            case Opcode.NOP: {
                 return;
             }
             case Opcode.LOAD_IMMEDIATE_1: {

--- a/src/cpu.ts
+++ b/src/cpu.ts
@@ -224,6 +224,7 @@ export class CpuArithmeticLogicUnit {
                 return;
             }
             case Opcode.ADD: {
+                this.targetRegister += this.cpu.generalRegisters[this.inputData];
                 return;
             }
             case Opcode.SUB: {

--- a/src/cpu.ts
+++ b/src/cpu.ts
@@ -228,6 +228,8 @@ export class CpuArithmeticLogicUnit {
                 return;
             }
             case Opcode.SUB: {
+                this.targetRegister -= this.cpu.generalRegisters[this.inputData];
+                this.targetRegister = this.targetRegister & 0xffffffff;
                 return;
             }
             case Opcode.MUL: {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -41,3 +41,7 @@ export function storeWordAtAddress(memory: Byte[], address: Word, value: Word) {
 export function storeBytes(memory: Byte[], bytes: Byte[], offset: Word = 0) {
     bytes.forEach((byte, i) => (memory[offset + i] = byte));
 }
+
+export function storeBytesAtAddress(memory: Byte[], address: Word, bytes: Byte[]) {
+    storeBytes(memory, bytes, address);
+}


### PR DESCRIPTION
This change sets the halt opcode to 0.
This enables asm programmers to omit the last opcode
as long as the content of the next byte is 0.

- **feat: storeBytesAtAddress**
- **refactor: use consistent abstraction level**
- **feat: implement add instruction**
- **feat: implement sub instruction**
- **feat: set opcode for halt to 0**
